### PR TITLE
Fix Citibike Hypothesis Test Notation

### DIFF
--- a/HW3_fb55/citibikes_gender.ipynb
+++ b/HW3_fb55/citibikes_gender.ipynb
@@ -69,15 +69,15 @@
     "## Women are less likely than men to choose biking _for commuting_\n",
     "\n",
     "# NULL HYPOTHESIS:\n",
-    "## The ratio of man biking on weekends over man biking on weekdays is _the same_ or _higher_  than the ratio of woman biking over weekends to woman biking on weekdays\n",
+    "## The proportion of men biking on weekends is _the same_ or _higher_  than the proportion of women biking on weekends\n",
     "\n",
-    "# _$H_0$_ : $\\frac{W_{\\mathrm{weekend}}}{W_{\\mathrm{week}}} <= \\frac{M_{\\mathrm{weekend}}}{M_{\\mathrm{week}}}$\n",
-    "# _$H_1$_ : $\\frac{W_{\\mathrm{weekend}}}{W_{\\mathrm{week}}} > \\frac{M_{\\mathrm{weekend}}}{M_{\\mathrm{week}}}$\n",
+    "# _$H_0$_ : $\\frac{W_{\\mathrm{weekend}}}{W_{\\mathrm{total}}} <= \\frac{M_{\\mathrm{weekend}}}{M_{\\mathrm{total}}}$\n",
+    "# _$H_1$_ : $\\frac{W_{\\mathrm{weekend}}}{W_{\\mathrm{total}}} > \\frac{M_{\\mathrm{total}}}{M_{\\mathrm{total}}}$\n",
     "\n",
     "or identically:\n",
     "\n",
-    "# _$H_0$_ : $\\frac{W_{\\mathrm{weekend}}}{W_{\\mathrm{week}}} - \\frac{M_{\\mathrm{weekend}}}{M_{\\mathrm{week}}} <= 0 $\n",
-    "# _$H_1$_ : $\\frac{W_{\\mathrm{weekend}}}{W_{\\mathrm{week}}} - \\frac{M_{\\mathrm{weekend}}}{M_{\\mathrm{week}}} > 0$\n",
+    "# _$H_0$_ : $\\frac{W_{\\mathrm{weekend}}}{W_{\\mathrm{total}}} - \\frac{M_{\\mathrm{weekend}}}{M_{\\mathrm{total}}} <= 0 $\n",
+    "# _$H_1$_ : $\\frac{W_{\\mathrm{weekend}}}{W_{\\mathrm{total}}} - \\frac{M_{\\mathrm{weekend}}}{M_{\\mathrm{total}}} > 0$\n",
     "## I will use a significance level  $\\alpha=0.05$\n",
     "\n",
     "#### which means i want the probability of getting a result at least as significant as mine to be less then 5%"
@@ -1405,9 +1405,9 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [conda root]",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "conda-root-py"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1419,7 +1419,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.3"
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,

--- a/HW3_fb55/citibikes_gender.ipynb
+++ b/HW3_fb55/citibikes_gender.ipynb
@@ -662,7 +662,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "we can add up the week and weekend days, then this becomes a test of proportions, (like the one seen in the [employment notebook](https://github.com/fedhere/UInotebooks/blob/master/hypothesistesting/effectivenes%20of%20NYC%20Post-Prison%20Employment%20Programs.save.ipynb))"
+    "we can add up the weekend days and normalize by the totals, then this becomes a test of proportions, (like the one seen in the [employment notebook](https://github.com/fedhere/UInotebooks/blob/master/hypothesistesting/effectivenes%20of%20NYC%20Post-Prison%20Employment%20Programs.save.ipynb))"
    ]
   },
   {
@@ -787,9 +787,9 @@
     "# $p =\\frac{p_0  n_0 + p_1  n_1}{n_0+n_1}$\n",
     "# $SE = \\sqrt{ p  ( 1 - p )  (\\frac{1}{n_0} + \\frac{1}{n_1}) }$\n",
     "## and in this notation \n",
-    "# $p_0 = \\frac{W_{\\mathrm{weekend}}}{W_{\\mathrm{week}}}$\n",
+    "# $p_0 = \\frac{W_{\\mathrm{weekend}}}{W_{\\mathrm{total}}}$\n",
     "### and \n",
-    "# $p_1 = \\frac{M_{\\mathrm{weekend}}}{M_{\\mathrm{week}}}$\n"
+    "# $p_1 = \\frac{M_{\\mathrm{weekend}}}{M_{\\mathrm{total}}}$\n"
    ]
   },
   {


### PR DESCRIPTION
I believe the test at the end is actually already looking at the proportion of (`weekend / total`) - I just changed the notation to reflect that.